### PR TITLE
[REFACTOR] BusDataTableView 를 상속한 busDataListView 로 변경

### DIFF
--- a/BUSERVE_iOS/BookMark/ViewController/BookmarkViewController.swift
+++ b/BUSERVE_iOS/BookMark/ViewController/BookmarkViewController.swift
@@ -9,26 +9,34 @@ import UIKit
 
 class BookmarkViewController: UIViewController {
     
-    lazy var busDataListView: UITableView = {
-        let tableView = UITableView()
-        tableView.separatorStyle = .none // cell line 없애기
-        tableView.register(BusDataTableViewCell.self, forCellReuseIdentifier: "BusCell")
-        return tableView
+    // MARK: - Properties
+    
+    private lazy var busDataListView = BusDataTableView(data: busDataModel, isSortBookMark: true)
+    
+    lazy var refreshControl: UIRefreshControl = {
+        let refreshControl = UIRefreshControl()
+        refreshControl.addTarget(self, action: #selector(handleRefresh(_:)), for: .valueChanged)
+        refreshControl.tintColor = UIColor.MainColor
+        return refreshControl
     }()
+    
+    // MARK: - Life Cycles
     
     override func viewDidLoad() {
         super.viewDidLoad()
         addSubviews()
         configureConstraints()
         
-        busDataListView.delegate = self
-        busDataListView.dataSource = self
-        busDataListView.delaysContentTouches = false
+        busDataListView.refreshControl = refreshControl
+
         view.backgroundColor = .white
     }
     
+    // MARK: - methods or layouts
+    
     private func addSubviews() {
         [busDataListView].forEach { view.addSubview($0) }
+        busDataListView.addSubview(refreshControl)
         busDataListView.translatesAutoresizingMaskIntoConstraints = false
     }
     
@@ -40,71 +48,12 @@ class BookmarkViewController: UIViewController {
             busDataListView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
         ])
     }
-}
-
-extension BookmarkViewController: ButtonTappedDelegate {
-    func cellButtonTapped(index: Int?) {
-        guard let index = index else {
-            return
-        }
-        print("\(busDataModel[index])")
-        
-        busDataModel[index].isBookmark.toggle()
-
-        print("\(busDataModel[index])")
-        
-        busDataListView.reloadData()
-    }
-}
-
-//  TableView 는 Cell 간격을 둘 수 없어 짝수번째의 Cell 에 데이터를 입력, 홀수번째는 빈 Cell 로 간격을 설정
-extension BookmarkViewController: UITableViewDelegate, UITableViewDataSource {
-    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return busDataModel.count * 2
-    }
     
-    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if indexPath.row % 2 == 0 {
-            return 138
-        } else {
-            return 20
-        }
-    }
-    
-    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        if indexPath.row % 2 == 0 {
-            let cell = tableView.dequeueReusableCell(withIdentifier: "BusCell", for: indexPath) as! BusDataTableViewCell
-
-            let index = indexPath.row / 2
-            
-            cell.index = index // Cell 의 Button 을 눌렀을 때 몇번째 Cell 인지 파악하기 위해 사용
-            
-            cell.delegate = self
-
-            cell.selectionStyle = .none
-            cell.layer.borderWidth = 1
-            cell.layer.cornerRadius = 16
-
-            let color: UIColor = .Tertiary
-            cell.layer.borderColor = color.cgColor
-            
-            let busData = busDataModel[index]
-            let routeMap = "\(busData.Departure + " ↔ " + busData.Arrival)"
-            
-            cell.busNum.text = "\(busData.busNumber)"
-            cell.routeMap.text = "\(routeMap)"
-            
-            if busData.isBookmark == true {
-                cell.bookmarkButton.configuration = UIButton.Configuration.bookmarkButtonStyle(style: .bookmarked)
-            } else {
-                cell.bookmarkButton.configuration = UIButton.Configuration.bookmarkButtonStyle(style: .notBookmarked)
-            }
-        
-            return cell
-                
-        } else {
-            
-            return UITableViewCell()
+    @objc func handleRefresh(_ refreshControl: UIRefreshControl) {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 1.0) {
+            self.busDataListView.busData = self.busDataListView.busData.filter{ $0.isBookmark == true }
+            self.busDataListView.reloadData()
+            self.busDataListView.refreshControl?.endRefreshing()
         }
     }
 }

--- a/BUSERVE_iOS/Home/View/BusDataTableView.swift
+++ b/BUSERVE_iOS/Home/View/BusDataTableView.swift
@@ -12,6 +12,7 @@ class BusDataTableView: UITableView {
     // MARK: - Properties
     
     var busData: [BusDataModel] = []
+    var isSortBookMark: Bool = false
     
     // MARK: - Life Cycles
     
@@ -21,15 +22,23 @@ class BusDataTableView: UITableView {
         self.separatorStyle = .none
         
         self.register(BusTableViewCell.self, forCellReuseIdentifier: "BusCellId")
-        self.isScrollEnabled = false
         self.delegate = self
         self.dataSource = self
     }
     
-    convenience init(data: [BusDataModel]) {
+    convenience init(data: [BusDataModel], isSortBookMark: Bool) {
         self.init(frame: .zero, style: .plain)
+        self.isSortBookMark = isSortBookMark
         self.busData = data
-        self.sortBusData()
+        
+        isSortBookMark ? self.sortBookmarkData() : self.sortBusData()
+        
+        if isSortBookMark {
+            self.isScrollEnabled = true
+        } else {
+            self.isScrollEnabled = false
+        }
+        
     }
     
     required init?(coder: NSCoder) {
@@ -42,10 +51,16 @@ class BusDataTableView: UITableView {
     private func sortBusData() {
         self.busData.sort { $0.isBookmark && !$1.isBookmark }
     }
+    
+    /// BookMark 페이지에서 Bookmark 된 데이터만 정렬해주는 함수
+    private func sortBookmarkData() {
+        self.busData = self.busData.filter{ $0.isBookmark == true }
+    }
 }
 
     // MARK: - TableView Delegate
 
+/// TableView 는 Cell 간격을 둘 수 없어 짝수번째의 Cell 에 데이터를 입력, 홀수번째는 빈 Cell 로 간격을 설정
 extension BusDataTableView: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         return busData.count * 2

--- a/BUSERVE_iOS/Home/ViewController/HomeViewController.swift
+++ b/BUSERVE_iOS/Home/ViewController/HomeViewController.swift
@@ -14,7 +14,7 @@ class HomeViewController: UIViewController {
     private lazy var onBoardBusButton = OnBoardBusButtonView()
     private lazy var homeTitleLabel = HomeTitleLabelView()
     private lazy var busSerachTextField =  BusSerachTextField()
-    private lazy var busTableView = BusDataTableView(data: busDataModel)
+    private lazy var busTableView = BusDataTableView(data: busDataModel, isSortBookMark: false)
 
     private lazy var homeScrollView: UIScrollView = {
         let scrollView = UIScrollView()
@@ -64,7 +64,7 @@ class HomeViewController: UIViewController {
     lazy var refreshControl: UIRefreshControl = {
         let refreshControl = UIRefreshControl()
         refreshControl.addTarget(self, action: #selector(handleRefresh(_:)), for: .valueChanged)
-        refreshControl.tintColor = UIColor.red
+        refreshControl.tintColor = UIColor.MainColor
         return refreshControl
     }()
     


### PR DESCRIPTION
## ✨ 해결한 이슈 
#18 

<br>

## 🛠️ 작업내용
- UITableView 를 상속받아 만든 busDataListView 를 BusDataTableView 로 상속 변경
- 따로 TableView 를 구현하지 않아도 동일한 TableView 를 구현

<br>

### 자세한 설명

`HomeViewController` 에 있는 `TableView` 와 `BookmarkViewController` 에 있는 TableView 는 UI 가 동일합니다 
먼저 작업한 `BookmarkViewController` 에 있는 TableView 를 만들 때 재사용성을 고려하지 않고 `UITalbeView` 를 상속 받아 구현하였습니다

그 다음에 `HomeViewCotroller` 의 TableView 를 만들 때 동일한 코드를 또 선언하게 되었고 코드를 유지 보수 할 때도 불편할거라 생각했습니다

동일한 TableView 를 만들기 위해 `BusDataTableView` 라는 `UITableView` 를 만들었고 해당 타입을 상속받아 TableView 를 구현하게 되었습니다

결과적으로 `ViewController` 에는 UI 에 대한 코드 부분을 줄일 수 있었고 유지보수 할 때도 `BusDataTableView` 를 변경하면 상속 받은 곳에 다 적용 되기 때문에 간편해졌습니다

<br>

## 📋 추후 진행 상황
- TabView 를 구현할 예정
- 소셜 로그인 기능을 구현할 예정

<br>

## 📌 리뷰 포인트
- 기존의 BookmarkViewController 이 잘 동작하는지 확인 부탁드립니다

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
