### PR TITLE
[FEAT]  SocialLoginManager 구현

### DIFF
--- a/BUSERVE_iOS.xcodeproj/project.pbxproj
+++ b/BUSERVE_iOS.xcodeproj/project.pbxproj
@@ -16,6 +16,9 @@
 		3F22B5CB2A7D0C400067D01C /* TextFieldExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F22B5CA2A7D0C400067D01C /* TextFieldExtension.swift */; };
 		3F3624B02A7DF0EB0066E531 /* BusDataTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3624AF2A7DF0EB0066E531 /* BusDataTableView.swift */; };
 		3F3624B22A7DF1FB0066E531 /* BusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3624B12A7DF1FB0066E531 /* BusTableViewCell.swift */; };
+		3F7DBD022A80678B00410404 /* AuthenticateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7DBD012A80678B00410404 /* AuthenticateAdapter.swift */; };
+		3F7DBD042A80680000410404 /* SocialLoginManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7DBD032A80680000410404 /* SocialLoginManager.swift */; };
+		3F7DBD062A806E3200410404 /* LoginUseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7DBD052A806E3200410404 /* LoginUseCase.swift */; };
 		3FD3CDD52A703CED005C405C /* FontExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD3CDD42A703CED005C405C /* FontExtension.swift */; };
 		3FD3CDDA2A704265005C405C /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD3CDD92A704265005C405C /* LoginViewController.swift */; };
 		3FD3CDDC2A7042DE005C405C /* SocialLoginButtonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FD3CDDB2A7042DE005C405C /* SocialLoginButtonView.swift */; };
@@ -76,6 +79,9 @@
 		3F22B5CA2A7D0C400067D01C /* TextFieldExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldExtension.swift; sourceTree = "<group>"; };
 		3F3624AF2A7DF0EB0066E531 /* BusDataTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusDataTableView.swift; sourceTree = "<group>"; };
 		3F3624B12A7DF1FB0066E531 /* BusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusTableViewCell.swift; sourceTree = "<group>"; };
+		3F7DBD012A80678B00410404 /* AuthenticateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateAdapter.swift; sourceTree = "<group>"; };
+		3F7DBD032A80680000410404 /* SocialLoginManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginManager.swift; sourceTree = "<group>"; };
+		3F7DBD052A806E3200410404 /* LoginUseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginUseCase.swift; sourceTree = "<group>"; };
 		3FD3CDD42A703CED005C405C /* FontExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontExtension.swift; sourceTree = "<group>"; };
 		3FD3CDD92A704265005C405C /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
 		3FD3CDDB2A7042DE005C405C /* SocialLoginButtonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SocialLoginButtonView.swift; sourceTree = "<group>"; };
@@ -173,9 +179,20 @@
 			path = ViewController;
 			sourceTree = "<group>";
 		};
+		3F7DBD002A80675D00410404 /* SocialLogin */ = {
+			isa = PBXGroup;
+			children = (
+				3F7DBD012A80678B00410404 /* AuthenticateAdapter.swift */,
+				3F7DBD032A80680000410404 /* SocialLoginManager.swift */,
+				3F7DBD052A806E3200410404 /* LoginUseCase.swift */,
+			);
+			path = SocialLogin;
+			sourceTree = "<group>";
+		};
 		3FD3CDD62A70422A005C405C /* Login */ = {
 			isa = PBXGroup;
 			children = (
+				3F7DBD002A80675D00410404 /* SocialLogin */,
 				3FD3CDD82A704250005C405C /* ViewController */,
 				3FD3CDD72A70424A005C405C /* View */,
 			);
@@ -511,6 +528,7 @@
 			files = (
 				3F22B5C92A7CFDA70067D01C /* BusSerachTextField.swift in Sources */,
 				3F22B5C32A7CD6290067D01C /* OnBoardBusButtonView.swift in Sources */,
+				3F7DBD042A80680000410404 /* SocialLoginManager.swift in Sources */,
 				483962DB2A6E46F1006ADC6E /* NoshowController.swift in Sources */,
 				BE2E573E2A761DF500AF2C30 /* MyInformationViewController.swift in Sources */,
 				BECCE5B52A7CD94400693D19 /* BusMoneyChargeViewController.swift in Sources */,
@@ -532,6 +550,7 @@
 				3F3624B02A7DF0EB0066E531 /* BusDataTableView.swift in Sources */,
 				3FD3CDE02A725679005C405C /* CompletedSignUpLabelView.swift in Sources */,
 				3FD3CDDE2A72565D005C405C /* CompletedSignUpViewController.swift in Sources */,
+				3F7DBD022A80678B00410404 /* AuthenticateAdapter.swift in Sources */,
 				3FD4F2BE2A7749530097E107 /* BusDataTableViewCell.swift in Sources */,
 				485DBAA02A6CCAEC00E1B3BE /* SeatReservationComplete.swift in Sources */,
 				BE2E573C2A761DF500AF2C30 /* ReservationDetail.swift in Sources */,
@@ -547,6 +566,7 @@
 				3FD3CDDA2A704265005C405C /* LoginViewController.swift in Sources */,
 				BE98EE0C2A6988F100FEA9E2 /* ColorExtension.swift in Sources */,
 				3FD3CDDC2A7042DE005C405C /* SocialLoginButtonView.swift in Sources */,
+				3F7DBD062A806E3200410404 /* LoginUseCase.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/BUSERVE_iOS/Login/SocialLogin/AuthenticateAdapter.swift
+++ b/BUSERVE_iOS/Login/SocialLogin/AuthenticateAdapter.swift
@@ -1,0 +1,14 @@
+//
+//  AuthenticateAdapter.swift
+//  BUSERVE_iOS
+//
+//  Created by ParkJunHyuk on 2023/08/07.
+//
+
+import Foundation
+
+protocol AuthenticateAdapter {
+    var adapterType: String { get }
+    
+    func login() async throws -> Bool
+}

--- a/BUSERVE_iOS/Login/SocialLogin/LoginUseCase.swift
+++ b/BUSERVE_iOS/Login/SocialLogin/LoginUseCase.swift
@@ -1,0 +1,24 @@
+//
+//  LoginUseCase.swift
+//  BUSERVE_iOS
+//
+//  Created by ParkJunHyuk on 2023/08/07.
+//
+
+import Foundation
+
+struct LoginUseCase {
+    let adapter: AuthenticateAdapter
+    
+    var adapterType: String {
+        return adapter.adapterType
+    }
+    
+    init(adapter: AuthenticateAdapter) {
+        self.adapter = adapter
+    }
+    
+    func login() async throws -> Bool {
+        return try await adapter.login()
+    }
+}

--- a/BUSERVE_iOS/Login/SocialLogin/SocialLoginManager.swift
+++ b/BUSERVE_iOS/Login/SocialLogin/SocialLoginManager.swift
@@ -1,0 +1,54 @@
+//
+//  SocialLoginManager.swift
+//  BUSERVE_iOS
+//
+//  Created by ParkJunHyuk on 2023/08/07.
+//
+
+import Foundation
+
+enum LoginResult {
+    case success
+    case failure(Error)
+}
+
+class SocialLoginManager {
+    
+    // MARK: - Properties
+    
+    static let shared = SocialLoginManager()
+    
+    private init() {}
+    
+    private(set) var isLoggedIn: Bool = false
+
+    var currentUseCase: LoginUseCase?
+    
+    // MARK: - methods
+    
+    func login(with adapter: AuthenticateAdapter) async throws -> LoginResult {
+        self.currentUseCase = LoginUseCase(adapter: adapter)
+        
+        guard let currentUseCase = self.currentUseCase else {
+            throw NSError(domain: "SocialLoginManagerError", code: 0, userInfo: [NSLocalizedDescriptionKey: "currentUseCase is nil."])
+        }
+        
+        do {
+            let result = try await currentUseCase.login()
+            isLoggedIn = true
+            return .success
+        } catch let error {
+            isLoggedIn = false
+            return .failure(error)
+        }
+    }
+    
+    func printCurrentUseCase() {
+        if let currentAdapter = currentUseCase {
+            print("Current use case is using \(currentAdapter.adapterType) adapter.")
+        } else {
+            print("No current use case.")
+        }
+    }
+}
+


### PR DESCRIPTION
## ✨ 해결한 이슈 
#20

<br>

## 🛠️ 작업내용
- LoginUseCase 구현
- AuthenticateAdapter Protocol 구현 
- SocialLoginManager 구현 

<br>

### 자세한 내용

#### 1. Adapter Pattern 적용 

현재 Kakao, Google, Apple Social Login 을 구현해야합니다
서로 다른 Class 로 만드는 것 보다 하나의 Class 에서 여러 Social Login 을 사용할 수 있는것이 더 효율적이라 판단되어 Adapter Pattern 을 적용시켰습니다

``` swift 
self.currentUseCase = LoginUseCase(adapter: adapter)
// ...
let result = try await currentUseCase.login()
```

위의 코드와 같이 해당하는 Social Login 에 대한 Adapter 를 입력 받아 login 함수를 호출하게 됩니다.
결과적으로 해당 Social Login 에 대한 로직을 몰라도 Social Login 을 바깥에서 호출이 가능하다는 점과 함께
다른 Social Login 을 손쉽게 추가 할 수 있는, 유지보수가 용이해집니다

<br>

#### 2. Use Case 적용

``` swift 
struct LoginUseCase {
    let adapter: AuthenticateAdapter
    
    var adapterType: String {
        return adapter.adapterType
    }
    
    init(adapter: AuthenticateAdapter) {
        self.adapter = adapter
    }
    
    func login() async throws -> Bool {
        return try await adapter.login()
    }
}
```

Use Case는 특정 비즈니스 로직을 나타내 관련된 작업들이 한 곳에 모여있게 되어 유지보수를 용이하게 하며, 로직을 이해하기 쉽게 만듭니다.
또한 비즈니스 로직이 한 곳에 집중되어 있기 때문에, 쉽게 재사용 할 수 있어 적용을 하였습니다.

위의 코드는 어떤 Social Login Adapter 로 되어있는지 확인할 수있는 `adapterType` 변수와 함께 LoginUseCase 를 구현하였습니다

<br>

## 📋 추후 진행 상황
- Kakao Social Login 을 구현할 예정

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
