### PR TITLE
[FEAT] TabBar 의 상단 테두리 구현

### DIFF
--- a/BUSERVE_iOS/TabBarViewController.swift
+++ b/BUSERVE_iOS/TabBarViewController.swift
@@ -21,9 +21,6 @@ class TabBarViewController: UITabBarController {
         self.tabBar.barTintColor = .DarkModeSecondBackground
         self.tabBar.isTranslucent = false // 시스템 상 블러 효과가 기본으로 적용되어 있어 제거해주는 역할
         self.tabBar.layer.cornerRadius = 30.0
-
-        self.tabBar.layer.borderColor = (traitCollection.userInterfaceStyle == .dark) ? UIColor.Secondary.cgColor : UIColor.Tertiary.cgColor
-        
         self.tabBar.layer.masksToBounds = true
         setupTabItems()
     }
@@ -38,26 +35,57 @@ class TabBarViewController: UITabBarController {
         tabFrame.origin.y = self.view.frame.size.height - 100
         self.tabBar.frame = tabFrame
         
-        setupTabBarLayout()
+        setupTopLineTabBarLayout()
    }
 
     
     // MARK: - Tab Setup
     
-    private func setupTabBarLayout() {
-        let roundedCorners: UIRectCorner = [.topLeft, .topRight]
-        let cornerRadii = CGSize(width: 25, height: 25)
-        let path = UIBezierPath(roundedRect: self.tabBar.bounds, byRoundingCorners: roundedCorners, cornerRadii: cornerRadii)
-        let maskLayer = CAShapeLayer()
-        maskLayer.path = path.cgPath
-        self.tabBar.layer.mask = maskLayer
-        
-        let borderLayer = CAShapeLayer()
-        borderLayer.path = path.cgPath
-        borderLayer.lineWidth = 1.5
-        borderLayer.strokeColor = UIColor.Tertiary.cgColor
-        borderLayer.fillColor = nil
-        self.tabBar.layer.addSublayer(borderLayer)
+    private func setupTopLineTabBarLayout() {
+        let layer = CAShapeLayer()
+        let path = UIBezierPath()
+
+        let cornerRadius: CGFloat = 30.0 // 탭바의 라운드 처리된 부분의 반경입니다.
+
+        // 좌측 상단 시작점
+        path.move(to: CGPoint(x: 0, y: cornerRadius))
+
+        // 좌측 상단 라운드 처리된 부분 그림
+        path.addArc(withCenter: CGPoint(x: cornerRadius, y: cornerRadius),
+                    radius: cornerRadius,
+                    startAngle: .pi,
+                    endAngle: 1.5 * .pi,
+                    clockwise: true)
+
+        // 상단 우측까지 그림
+        path.addLine(to: CGPoint(x: tabBar.bounds.width - cornerRadius, y: 0))
+
+        // 우측 상단 라운드 처리된 부분 그림
+        path.addArc(withCenter: CGPoint(x: tabBar.bounds.width - cornerRadius, y: cornerRadius),
+                    radius: cornerRadius,
+                    startAngle: 1.5 * .pi,
+                    endAngle: 2 * .pi,
+                    clockwise: true)
+
+        layer.path = path.cgPath
+        layer.strokeColor = UIColor.Tertiary_SecondaryColor.cgColor //(traitCollection.userInterfaceStyle == .dark) ? UIColor.Secondary.cgColor : UIColor.Tertiary.cgColor // 테두리 색상 설정
+        layer.lineWidth = 1.5 // 테두리 두께 설정
+        layer.fillColor = UIColor.clear.cgColor
+
+        let gradientLayer = CAGradientLayer()
+        gradientLayer.frame = CGRect(x: 0, y: 0, width: tabBar.bounds.width, height: cornerRadius * 2) // gradientLayer의 크기 설정
+        gradientLayer.colors = [UIColor.clear.cgColor,
+                                layer.strokeColor!,
+                                layer.strokeColor!,
+                                UIColor.clear.cgColor] // 알파값이 변화하는 그라디언트
+
+        let roundPercent = cornerRadius / tabBar.bounds.width
+        gradientLayer.locations = [0, NSNumber(value: Float(roundPercent)), NSNumber(value: 1.0 - Float(roundPercent)), 1]
+        gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
+        gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)
+
+        tabBar.layer.addSublayer(layer)
+        layer.mask = gradientLayer  // gradientLayer를 mask로 설정하여 두께를 조절
     }
     
     private func setupTabItems() {

--- a/BUSERVE_iOS/TabBarViewController.swift
+++ b/BUSERVE_iOS/TabBarViewController.swift
@@ -38,7 +38,6 @@ class TabBarViewController: UITabBarController {
         setupTopLineTabBarLayout()
    }
 
-    
     // MARK: - Tab Setup
     
     private func setupTopLineTabBarLayout() {


### PR DESCRIPTION
## ✨ 해결한 이슈 
#33 

<br>

## 🛠️ 작업내용
- Tabbar 의 상단 테두리를 구현
- DarkMode 를 지원

|LightMode TabBar|DarkMode TabBar|
|------|------|
|<img width="200" alt="iPhone 13 mini - 2023-08-04 at 19 18 38" src="https://github.com/BUSERVE/buserve-ios/assets/45564605/583406a5-75b9-4d47-b955-834e5d3f3bba">|<img width="200" alt="iPhone 13 mini - 2023-08-06 at 11 30 14" src="https://github.com/BUSERVE/buserve-ios/assets/45564605/16590104-1f58-4e50-ace1-9ca59126d7e6">|

<br>

### 자세한 설명 

#### 1. `CAShapeLayer` 로 직접 TabBar 의 테두리를 구현

TabBar 의 테두리는 `self.tabBar.layer.borderWidth` 로 구현이 가능합니다.
하지만 상하좌우 모든 곳에 테두리가 생성되며 상단에만 필요한 테두리를 구현하기 어려움이 많았습니다.

결과적으로 직접 구현을 해야했으며 `CAShapeLayer` 와 `UIBezierPath` 를 통해 직접 선을 구현하였습니다. 

``` swift
// 좌측 상단 시작점
path.move(to: CGPoint(x: 0, y: cornerRadius))

// 좌측 상단 라운드 처리된 부분 그림
path.addArc(withCenter: CGPoint(x: cornerRadius, y: cornerRadius),
            radius: cornerRadius,
            startAngle: .pi,
            endAngle: 1.5 * .pi,
            clockwise: true)

// 상단 우측까지 그림
path.addLine(to: CGPoint(x: tabBar.bounds.width - cornerRadius, y: 0))

// 우측 상단 라운드 처리된 부분 그림
path.addArc(withCenter: CGPoint(x: tabBar.bounds.width - cornerRadius, y: cornerRadius),
            radius: cornerRadius,
            startAngle: 1.5 * .pi,
            endAngle: 2 * .pi,
            clockwise: true)
```

첫번째로는 `UIBezierPath` 을 사용하여 좌,우측의 라운드를 표현하였습니다. 

``` swift
layer.path = path.cgPath
layer.strokeColor = UIColor.Tertiary_SecondaryColor.cgColorUIColor.Secondary.cgColor : UIColor.Tertiary.cgColor // 테두리 색상 설정
layer.lineWidth = 1.5 // 테두리 두께 설정
layer.fillColor = UIColor.clear.cgColor
```

두번째로는 좌,우측의 라운드를 구현해놓고 CAShapeLayer 로 만든 선에 추가하였으며 색상과 테두리를 구현하였습니다.

<br>

#### 2. `CAGradientLayer()` 을 통해 얇아지는 테두리 구현

``` swift
let gradientLayer = CAGradientLayer()
gradientLayer.frame = CGRect(x: 0, y: 0, width: tabBar.bounds.width, height: cornerRadius * 2) // gradientLayer의 크기 설정
gradientLayer.colors = [UIColor.clear.cgColor,
                        layer.strokeColor!,
                        layer.strokeColor!,
                        UIColor.clear.cgColor] // 알파값이 변화하는 그라디언트

let roundPercent = cornerRadius / tabBar.bounds.width
gradientLayer.locations = [0, NSNumber(value: Float(roundPercent)), NSNumber(value: 1.0 - Float(roundPercent)), 1]
gradientLayer.startPoint = CGPoint(x: 0, y: 0.5)
gradientLayer.endPoint = CGPoint(x: 1, y: 0.5)

tabBar.layer.addSublayer(layer)
layer.mask = gradientLayer
```

상단에 위치한 테두리는 같은 두께로 이루어지지 않고 좌우로 갈수록 얇아지는 형태를 갖고 있습니다.
테두리의 두께를 직접 변경하기 보다 gradient 를 통해 얇아지는 것처럼 직접 구현을 하였습니다. 

gradient 를 넣을 부분을 기존의 선의 두께, 형태에 맞게 frame 을 설정하고 시작과 끝나는 포인트를 설정하여 얇아지는 것처럼 구현을 하였습니다.

<br>

## 📋 추후 진행 상황
- 좌석 예약하기 버튼을 누를 시 알림창을 띄우는 로직을 구현합니다.

<br>

## 📌 리뷰 포인트
- TabBar 의 테두리 UI 가 잘 구현되어있는지 확인 부탁드립니다

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
