### PR TITLE
[FEAT] BusTableViewCell 의 Button 에 대한 동작 추가 및 관련 동작 구현

### DIFF
--- a/BUSERVE_iOS.xcodeproj/project.pbxproj
+++ b/BUSERVE_iOS.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		3F22B5CB2A7D0C400067D01C /* TextFieldExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F22B5CA2A7D0C400067D01C /* TextFieldExtension.swift */; };
 		3F3624B02A7DF0EB0066E531 /* BusDataTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3624AF2A7DF0EB0066E531 /* BusDataTableView.swift */; };
 		3F3624B22A7DF1FB0066E531 /* BusTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F3624B12A7DF1FB0066E531 /* BusTableViewCell.swift */; };
+		3F72E80A2A8F973B008E2579 /* NavigationExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F72E8092A8F973B008E2579 /* NavigationExtension.swift */; };
 		3F78D46F2A8BC40600815CCD /* PlaceHolderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F78D46E2A8BC40600815CCD /* PlaceHolderView.swift */; };
 		3F78D4712A8BC56900815CCD /* AnimationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F78D4702A8BC56900815CCD /* AnimationModel.swift */; };
 		3F7DBD022A80678B00410404 /* AuthenticateAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F7DBD012A80678B00410404 /* AuthenticateAdapter.swift */; };
@@ -108,6 +109,7 @@
 		3F22B5CA2A7D0C400067D01C /* TextFieldExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextFieldExtension.swift; sourceTree = "<group>"; };
 		3F3624AF2A7DF0EB0066E531 /* BusDataTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusDataTableView.swift; sourceTree = "<group>"; };
 		3F3624B12A7DF1FB0066E531 /* BusTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BusTableViewCell.swift; sourceTree = "<group>"; };
+		3F72E8092A8F973B008E2579 /* NavigationExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationExtension.swift; sourceTree = "<group>"; };
 		3F78D46E2A8BC40600815CCD /* PlaceHolderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaceHolderView.swift; sourceTree = "<group>"; };
 		3F78D4702A8BC56900815CCD /* AnimationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnimationModel.swift; sourceTree = "<group>"; };
 		3F7DBD012A80678B00410404 /* AuthenticateAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthenticateAdapter.swift; sourceTree = "<group>"; };
@@ -476,6 +478,7 @@
 				3FD4F2C12A77560C0097E107 /* ButtonExtension.swift */,
 				3F22B5C42A7CE7710067D01C /* ImageExtension.swift */,
 				3F22B5CA2A7D0C400067D01C /* TextFieldExtension.swift */,
+				3F72E8092A8F973B008E2579 /* NavigationExtension.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -708,6 +711,7 @@
 				BE2E57412A761DF500AF2C30 /* ReservationDetailCell.swift in Sources */,
 				BE2E57392A761DF500AF2C30 /* BuserveHelpViewController.swift in Sources */,
 				48FB18F22A8522BD00ABA58A /* BusStopTableViewCell.swift in Sources */,
+				3F72E80A2A8F973B008E2579 /* NavigationExtension.swift in Sources */,
 				BE2E57402A761DF500AF2C30 /* LogOutViewController.swift in Sources */,
 				3FD3CDD52A703CED005C405C /* FontExtension.swift in Sources */,
 				488199042A6791CD00D7C698 /* SceneDelegate.swift in Sources */,

--- a/BUSERVE_iOS/Assets.xcassets/Color/Secondary_DarkModeBackground.colorset/Contents.json
+++ b/BUSERVE_iOS/Assets.xcassets/Color/Secondary_DarkModeBackground.colorset/Contents.json
@@ -4,10 +4,10 @@
       "color" : {
         "color-space" : "srgb",
         "components" : {
-          "alpha" : "1.000",
-          "blue" : "255",
-          "green" : "255",
-          "red" : "255"
+          "alpha" : "0.750",
+          "blue" : "244",
+          "green" : "244",
+          "red" : "244"
         }
       },
       "idiom" : "universal"
@@ -23,9 +23,9 @@
         "color-space" : "srgb",
         "components" : {
           "alpha" : "1.000",
-          "blue" : "27",
-          "green" : "23",
-          "red" : "23"
+          "blue" : "0.106",
+          "green" : "0.090",
+          "red" : "0.090"
         }
       },
       "idiom" : "universal"

--- a/BUSERVE_iOS/Base.lproj/Main.storyboard
+++ b/BUSERVE_iOS/Base.lproj/Main.storyboard
@@ -2,7 +2,7 @@
 <document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21701" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="oCn-YF-5Qd">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21679"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="21678"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
@@ -39,7 +39,7 @@
         <!--Noshow-->
         <scene sceneID="y6Y-v8-cja">
             <objects>
-                <viewController storyboardIdentifier="NoShow" id="gQ3-ti-rW8" customClass="Noshow" customModule="BUSERVE_iOS" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NoShow" hidesBottomBarWhenPushed="YES" id="gQ3-ti-rW8" customClass="Noshow" customModule="BUSERVE_iOS" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="yYq-LI-RYk">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -61,7 +61,7 @@
                                         <lineBreakStrategy key="lineBreakStrategy" pushOut="YES" hangulWordPriority="YES"/>
                                     </label>
                                 </subviews>
-                                <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                                <color key="backgroundColor" name="Secondary_DarkModeBackground"/>
                                 <constraints>
                                     <constraint firstAttribute="trailing" secondItem="BAA-ez-eIA" secondAttribute="trailing" constant="20" id="EWD-GX-v4f"/>
                                     <constraint firstItem="BAA-ez-eIA" firstAttribute="leading" secondItem="Ec6-BW-HB2" secondAttribute="leading" constant="20" id="P79-st-Dk1"/>
@@ -1276,7 +1276,7 @@
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <stackView opaque="NO" contentMode="scaleToFill" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="6Aq-W0-JwQ">
-                                        <rect key="frame" x="44.666666666666686" y="179.66666666666669" width="267.99999999999994" height="19.333333333333343"/>
+                                        <rect key="frame" x="44.666666666666686" y="179.66666666666669" width="268" height="19.333333333333343"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="·" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ObY-m7-aOw">
                                                 <rect key="frame" x="0.0" y="0.0" width="4.666666666666667" height="19.333333333333332"/>
@@ -2451,6 +2451,9 @@
         </namedColor>
         <namedColor name="SecondaryBackground">
             <color red="0.9570000171661377" green="0.9570000171661377" blue="0.9570000171661377" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </namedColor>
+        <namedColor name="Secondary_DarkModeBackground">
+            <color red="0.52499997615814209" green="0.55699998140335083" blue="0.58799999952316284" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <namedColor name="Tertiary">
             <color red="0.80400002002716064" green="0.82700002193450928" blue="0.85100001096725464" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>

--- a/BUSERVE_iOS/CustomAlert/PopUpViewController.swift
+++ b/BUSERVE_iOS/CustomAlert/PopUpViewController.swift
@@ -16,7 +16,7 @@ class PopUpViewController: UIViewController {
 
     private lazy var containerView: UIView = {
         let view = UIView()
-        view.backgroundColor = .white
+        view.backgroundColor = .ButtonAlertBackground // .white
         view.layer.cornerRadius = 16
         view.transform = CGAffineTransform(scaleX: 1.1, y: 1.1)
 
@@ -47,7 +47,7 @@ class PopUpViewController: UIViewController {
         label.text = messageText
         label.textAlignment = .center
         label.font = UIFont(name: "Pretendard-Regular", size: 16)
-        label.textColor = UIColor(red: 0.204, green: 0.227, blue: 0.251, alpha: 1)
+        label.textColor = .Body // UIColor(red: 0.204, green: 0.227, blue: 0.251, alpha: 1)
         label.numberOfLines = 0
 
         if let attributedMessageText = attributedMessageText?.mutableCopy() as? NSMutableAttributedString {

--- a/BUSERVE_iOS/Extension/NavigationExtension.swift
+++ b/BUSERVE_iOS/Extension/NavigationExtension.swift
@@ -1,0 +1,41 @@
+//
+//  NavigationExtension.swift
+//  BUSERVE_iOS
+//
+//  Created by ParkJunHyuk on 2023/08/18.
+//
+
+import Foundation
+import UIKit
+
+extension UINavigationController {
+    func setCustomBackButton(title: String? = nil, image: UIImage? = nil, sfSymbol: String? = nil, textColor: UIColor? = nil, imageColor: UIColor? = nil, weight: UIImage.SymbolWeight? = nil) {
+        guard let topVC = self.topViewController else { return }
+
+        let backButton: UIBarButtonItem
+        
+        if let title = title {
+            backButton = UIBarButtonItem(title: title, style: .plain, target: topVC, action: #selector(topVC.leftBackButtonTapped))
+            backButton.tintColor = textColor
+        } else if let image = image {
+            backButton = UIBarButtonItem(image: image, style: .plain, target: topVC, action: #selector(topVC.leftBackButtonTapped))
+            backButton.tintColor = imageColor
+        } else if let sfSymbol = sfSymbol {
+            let config = UIImage.SymbolConfiguration(weight: weight ?? .regular)
+            let systemImage = UIImage(systemName: sfSymbol, withConfiguration: config)
+            backButton = UIBarButtonItem(image: systemImage, style: .plain, target: topVC, action: #selector(topVC.leftBackButtonTapped))
+            backButton.tintColor = imageColor
+        } else {
+            return
+        }
+
+        topVC.navigationItem.leftBarButtonItem = backButton
+        topVC.navigationItem.hidesBackButton = true
+    }
+}
+
+extension UIViewController {
+    @objc func leftBackButtonTapped() {
+        navigationController?.popViewController(animated: true)
+    }
+}

--- a/BUSERVE_iOS/Home/View/BusDataTableView.swift
+++ b/BUSERVE_iOS/Home/View/BusDataTableView.swift
@@ -13,6 +13,7 @@ class BusDataTableView: UITableView {
     
     var busData: [BusDataModel] = []
     var isSortBookMark: Bool = false
+    weak var viewControllerDelegate: BusTableViewCellDelegate?
     
     // MARK: - Life Cycles
     
@@ -82,7 +83,7 @@ extension BusDataTableView: UITableViewDelegate, UITableViewDataSource {
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         if indexPath.row % 2 == 0 {
             let cell = tableView.dequeueReusableCell(withIdentifier: "BusCellId", for: indexPath) as! BusTableViewCell
-            
+            cell.delegate = viewControllerDelegate
             cell.backgroundColor = .DarkModeSecondBackground
             cell.selectionStyle = .none
             cell.layer.borderWidth = (traitCollection.userInterfaceStyle == .dark) ? 0 : 1

--- a/BUSERVE_iOS/Home/View/BusTableViewCell.swift
+++ b/BUSERVE_iOS/Home/View/BusTableViewCell.swift
@@ -13,6 +13,7 @@ class BusTableViewCell: UITableViewCell {
 
     static let busCellId = "BusCellId"
     var onBookmarkButtonTap: (() -> Void)?
+    weak var delegate: BusTableViewCellDelegate?
     
     lazy var busImage: UIImageView = {
        let image = UIImageView(frame: CGRect(x: 0, y: 0, width: 18, height: 18))
@@ -146,7 +147,7 @@ class BusTableViewCell: UITableViewCell {
     }
 
     @objc func reservationButtonClicked(_ sender: UIButton) {
-        print("좌석 예약하기")
+        delegate?.didTapReservationButton()
     }
     
     func settingBookmarkButton(isBookmarked: Bool) {
@@ -165,4 +166,8 @@ class BusTableViewCell: UITableViewCell {
             busImage.image = (traitCollection.userInterfaceStyle == .dark) ? UIImage(named: "DarkModeBus") : UIImage(named: "LightModeBus")
         }
     }
+}
+
+protocol BusTableViewCellDelegate: AnyObject {
+    func didTapReservationButton()
 }

--- a/BUSERVE_iOS/Home/ViewController/HomeViewController.swift
+++ b/BUSERVE_iOS/Home/ViewController/HomeViewController.swift
@@ -95,7 +95,7 @@ class HomeViewController: UIViewController {
         self.placeHolderView.isHidden = true
         busSearchTextField.searchDelegate = self
         busSearchTextField.delegate = self
-        
+        busTableView.viewControllerDelegate = self
         addSubviews()
         configureConstraints()
         hideKeyboardWhenTappedAround()
@@ -215,7 +215,6 @@ extension HomeViewController {
             self.showHideAnimationView(.show)
             self.upDownAnimationTabbar(.up)
 
-            
             self.view.layoutIfNeeded()
         } completion: { _ in
             self.searchBusTableView.isHidden = true
@@ -369,4 +368,37 @@ extension HomeViewController: UITextFieldDelegate {
 
 protocol HomeViewControllerDelegate: AnyObject {
     func shouldHideTabBar(_ hide: Bool)
+}
+
+extension HomeViewController: BusTableViewCellDelegate {
+    func didTapReservationButton() {
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        let message = "버스 좌석을 예약하시려면\n노쇼 방지를 위해서\n위치 인증이 필요해요."
+        let attributedString = NSMutableAttributedString(string: message)
+        
+        // PopUpViewController 인스턴스 생성
+        let popUpVC = PopUpViewController(attributedMessageText: attributedString)
+
+        // 버튼 및 동작 추가 (옵션)
+        popUpVC.addActionBtn(title: "취소", titleColor: .Secondary, backgroundColor: .ButtonAlertBackground) {
+            popUpVC.dismiss(animated: true, completion: nil)
+        }
+        
+        // 버튼 및 동작 추가 (옵션)
+        popUpVC.addActionBtn(title: "위치 인증하기", titleColor: .white, backgroundColor: .MainColor) {
+            guard let noshow = storyboard.instantiateViewController(withIdentifier: "NoShow") as? Noshow else {
+                print("Failed to instantiate Noshow")
+                return
+            }
+
+            popUpVC.dismiss(animated: true) {
+                print("PopUp dismissed")
+                noshow.hidesBottomBarWhenPushed = true
+                self.navigationController?.pushViewController(noshow, animated: true)
+            }
+        }
+        
+        // 팝업 뷰 컨트롤러 띄우기
+        self.present(popUpVC, animated: true, completion: nil)
+    }
 }

--- a/BUSERVE_iOS/NoshowController.swift
+++ b/BUSERVE_iOS/NoshowController.swift
@@ -19,13 +19,16 @@ class Noshow: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
+        self.navigationController?.isNavigationBarHidden = false
         
+        self.navigationController?.setCustomBackButton(sfSymbol: "chevron.left", imageColor: .Body, weight: .bold)
+
         
         TitleLabel.font = UIFont(name: "Pretendard-Bold", size: 24)
-        TitleLabel.textColor = UIColor(red: 0.20, green: 0.23, blue: 0.25, alpha: 1.00)
+        TitleLabel.textColor = .Body // UIColor(red: 0.20, green: 0.23, blue: 0.25, alpha: 1.00)
         
         
-        InforView.backgroundColor = UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.00).withAlphaComponent(0.75)
+//        InforView.backgroundColor = UIColor(red: 0.96, green: 0.96, blue: 0.96, alpha: 1.00).withAlphaComponent(0.75)
         InforView.layer.cornerRadius = 16
         
         let text =
@@ -74,10 +77,10 @@ class Noshow: UIViewController {
             i.layer.cornerRadius = i.layer.frame.size.width / 2
             i.tintColor = UIColor.white
             if i == ClickBtn.first{
-                i.backgroundColor = UIColor(red: 0.80, green: 0.83, blue: 0.85, alpha: 1.00)
-                i.setImage(UIImage(named: "Cancel.png"), for: .normal)
+                i.backgroundColor = .Tertiary_SecondaryColor // UIColor(red: 0.80, green: 0.83, blue: 0.85, alpha: 1.00)
+                i.setImage(UIImage(named: "cancel.png"), for: .normal)
             }else{
-                i.backgroundColor = UIColor(red: 0.07, green: 0.41, blue: 0.98, alpha: 1.00)
+                i.backgroundColor = .MainColor // UIColor(red: 0.07, green: 0.41, blue: 0.98, alpha: 1.00)
                 i.setImage(UIImage(named: "Check.png"), for: .normal)
             }
         }

--- a/BUSERVE_iOS/TabBarViewController.swift
+++ b/BUSERVE_iOS/TabBarViewController.swift
@@ -27,8 +27,6 @@ class TabBarViewController: UITabBarController {
     
     override func viewDidLayoutSubviews() {
        super.viewDidLayoutSubviews()
-
-        self.tabBar.isHidden = false
         
         var tabFrame = self.tabBar.frame
         tabFrame.size.height = 100


### PR DESCRIPTION
## ✨ 해결한 이슈 
#35

## 🛠️ 작업내용
- BusTableViewCell 의 reservationButton 동작을 추가
- NoshowController 와 PopUpViewController 의 다크모드 지원
- UINavigationController 에 backbutton 을 만드는 로직 구현 
- Noshow 에 backbutton 추가

https://github.com/BUSERVE/buserve-ios/assets/45564605/288e2cce-6e07-4355-a743-59b8fb4647a8

<br>

### 자세한 사항

#### 1. BusTableViewCell 안에 있는 Button 에 `pushViewController()` 메서드 구현

UITableViewCell 안에서는 storyboard에 직접적으로 접근할 수 없습니다.
BusTableViewCell 내부의 버튼 클릭 이벤트에서 ViewController를 띄우기 위해서는 Delegate 패턴 또는 Notification을 사용하여 해당 동작을 TableView를 포함하고 있는 ViewController 에서 작업을 해야합니다. 

여기서는 Delegate 패턴을 사용했으며 다음과 같이 진행하였습니다. 

``` swift
protocol BusTableViewCellDelegate: AnyObject {
    func didTapReservationButton()
}

class BusTableViewCell: UITableViewCell {
    weak var delegate: BusTableViewCellDelegate?
    //....
}

class BusDataTableView: UITableView {
    weak var viewControllerDelegate: BusTableViewCellDelegate?

    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
        //...
        cell.delegate = viewControllerDelegate
    }
}

class HomeViewController: UIViewController, BusTableViewCellDelegate {

    //...
    override func viewDidLoad() {
        busTableView.viewControllerDelegate = self
    }

    func didTapReservationButton() {
        //... 
        
        // 버튼 및 동작 추가 (옵션)
        popUpVC.addActionBtn(title: "위치 인증하기", titleColor: .white, backgroundColor: .MainColor) {
            guard let noshow = storyboard.instantiateViewController(withIdentifier: "NoShow") as? Noshow else {
                print("Failed to instantiate Noshow")
                return
            }
            //...
        }
        //...
    }
}
```

<br>

#### 2. 뒤로가기 버튼을 만드는 로직을 UINavigationController 에 extension 으로 추가

``` swift
extension UINavigationController {
    func setCustomBackButton(title: String? = nil, image: UIImage? = nil, sfSymbol: String? = nil, textColor: UIColor? = nil, imageColor: UIColor? = nil, weight: UIImage.SymbolWeight? = nil) {
        guard let topVC = self.topViewController else { return }

        let backButton: UIBarButtonItem
        
        if let title = title {
            backButton = UIBarButtonItem(title: title, style: .plain, target: topVC, action: #selector(topVC.leftBackButtonTapped))
            backButton.tintColor = textColor
        } else if let image = image {
            backButton = UIBarButtonItem(image: image, style: .plain, target: topVC, action: #selector(topVC.leftBackButtonTapped))
            backButton.tintColor = imageColor
        } else if let sfSymbol = sfSymbol {
            let config = UIImage.SymbolConfiguration(weight: weight ?? .regular)
            let systemImage = UIImage(systemName: sfSymbol, withConfiguration: config)
            backButton = UIBarButtonItem(image: systemImage, style: .plain, target: topVC, action: #selector(topVC.leftBackButtonTapped))
            backButton.tintColor = imageColor
        } else {
            return
        }

        topVC.navigationItem.leftBarButtonItem = backButton
        topVC.navigationItem.hidesBackButton = true
    }
}

extension UIViewController {
    @objc func leftBackButtonTapped() {
        navigationController?.popViewController(animated: true)
    }
}
```

NavigationBar 가 있거나 없는 ViewController 가 존재합니다.
즉, 해당 ViewController 마다 뒤로가기 버튼을 만들어주어야 하기 때문에 
손쉽게 만들 수 있도록 Extension 으로 `setCustomBackButton()` 메서드를 따로 구현하였습니다

<br>

## 📋 추후 진행 상황
- Social Login 을 진행할 예정

<br>

## 📌 리뷰 포인트
- Home 화면에서 좌석 예약하기 버튼이 잘 동작하는지 확인해주세요

<br>

## ✅ Checklist
- [x] 필요없는 주석, 프린트문 제거했는지 확인
- [x] 컨벤션 지켰는지 확인
